### PR TITLE
Republish as stableforks repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+(This is a fork from https://github.com/p1c2u/openapi-spec-validator)
+
 # OpenAPI Spec validator
 
 [![Package Version](https://img.shields.io/pypi/v/openapi-spec-validator.svg)](https://pypi.python.org/pypi/openapi-spec-validator)
-[![Build Status](https://travis-ci.org/p1c2u/openapi-spec-validator.svg?branch=master)](https://travis-ci.org/p1c2u/openapi-spec-validator)
-[![Code Coverage](https://img.shields.io/codecov/c/github/p1c2u/openapi-spec-validator/master.svg?style=flat)](https://codecov.io/github/p1c2u/openapi-spec-validator?branch=master)
+[![Build Status](https://travis-ci.org/stableforks/stableforks-openapi-spec-validator.svg?branch=master)](https://travis-ci.org/stableforks/stableforks-openapi-spec-validator)
+[![Code Coverage](https://img.shields.io/codecov/c/github/stableforks/stableforks-openapi-spec-validator/master.svg?style=flat)](https://codecov.io/github/stableforks/stableforks-openapi-spec-validator?branch=master)
 [![PyPI Version](https://img.shields.io/pypi/pyversions/openapi-spec-validator.svg)](https://pypi.python.org/pypi/openapi-spec-validator)
 [![PyPI Format](https://img.shields.io/pypi/format/openapi-spec-validator.svg)](https://pypi.python.org/pypi/openapi-spec-validator)
 [![PyPI Status](https://img.shields.io/pypi/status/openapi-spec-validator.svg)](https://pypi.python.org/pypi/openapi-spec-validator)

--- a/openapi_spec_validator/__init__.py
+++ b/openapi_spec_validator/__init__.py
@@ -10,7 +10,7 @@ from openapi_spec_validator.validators import SpecValidator
 __author__ = 'Artur Maciag'
 __email__ = 'maciag.artur@gmail.com'
 __version__ = '0.2.5'
-__url__ = 'https://github.com/p1c2u/openapi-spec-validator'
+__url__ = 'https://github.com/stableforks/stableforks-openapi-spec-validator'
 __license__ = 'Apache License, Version 2.0'
 
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ metadata = get_metadata(init_py)
 
 
 setup(
-    name='openapi-spec-validator',
+    name='stableforks-openapi-spec-validator',
     version=metadata['version'],
     author=metadata['author'],
     author_email=metadata['email'],


### PR DESCRIPTION
Republish a copy from the forked repo https://github.com/p1c2u/openapi-spec-validator
To prepare usage as a dependency in another project